### PR TITLE
fix: configuration typo in coc-jsref ("enabled" to "enable")

### DIFF
--- a/coc/extension.ts
+++ b/coc/extension.ts
@@ -4,7 +4,7 @@ import { ExtensionContext, services, workspace, TransportKind, LanguageClient } 
 const languages = ['javascript', 'javascriptreact', 'typescript', 'typescriptreact'];
 
 export async function activate(context: ExtensionContext): Promise<void> {
-  const config = workspace.getConfiguration('coc-jsref')
+  const config = workspace.getConfiguration('jsref')
   const isEnable = config.get<boolean>('enable', true)
   if (!isEnable) {
     return
@@ -19,8 +19,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
     documentSelector: languages.map((language) => ({ scheme: 'file', language })),
   };
   const client = new LanguageClient(
-    'coc-jsref', // the id
-    'coc-jsref', // the name of the language server
+    'jsref', // the id
+    'jsref', // the name of the language server
     serverOptions,
     clientOptions
   );

--- a/coc/package.json
+++ b/coc/package.json
@@ -26,7 +26,7 @@
       "type": "object",
       "title": "coc-jsref configuration",
       "properties": {
-        "coc-jsref.enabled": {
+        "jsref.enable": {
           "type": "boolean",
           "default": true,
           "description": "Enable coc-jsref extension"


### PR DESCRIPTION
There is a setting to enable and disable extensions, but there seems to be a typo and it does not work properly.

**Fixed**:

- Changed `enabled` to `enable` (In the code, since using `enable`) 
  - REF: https://github.com/slonoed/jsref/blob/master/coc/package.json#L29
  - REF: https://github.com/slonoed/jsref/blob/master/coc/extension.ts#L8
- Changed `coc-jsref` to `jsref` in "coc/extension.ts" (Because `coc-` is redundant)